### PR TITLE
split filestream into two classes

### DIFF
--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/BazelBuildEventsFileStream.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/BazelBuildEventsFileStream.java
@@ -5,36 +5,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.salesforce.bazel.sdk.bep.event.BEPEvent;
-import com.salesforce.bazel.sdk.bep.file.BazelBuildEventsFileContents;
-import com.salesforce.bazel.sdk.bep.file.BazelBuildEventsFileParser;
+import com.salesforce.bazel.sdk.bep.file.BEPMonitoredFile;
+import com.salesforce.bazel.sdk.bep.file.BEPFileContents;
+import com.salesforce.bazel.sdk.bep.file.BEPFileParser;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 
 /**
- * Bazel build event protocol stream (BEP) for a Bazel workspace. A BEP stream allows you to monitor and react to build
- * events emitted from Bazel.
+/**
+ * Bazel build event protocol stream (BEP) for a Bazel workspace. This implementation reads a file,
+ * publishes the events in the file to the subscriber(s), and ends the stream.
  * <p>
  * Because this stream integrates with your builds with Bazel using BEP, this stream will work with command line builds
  * but also with IDE builds.
  * <p>
  * After creation, you must start the stream by calling activateStream().
  * <p>
- * <b>NOTE:</b> This feature requires a configuration change to your Bazel workspace: you must add the following lines
+ * <b>NOTE:</b> This feature requires you to provide BEP JSON file(s). These can be generated with a configuration 
+ * change to your Bazel workspace: you must add the following lines
  * to your .bazelrc file to enable BEP:<br/>
  * build --build_event_json_file bep_build.json<br/>
  * test --build_event_json_file bep_test.json<br/>
  * <p>
  * In the above example, you must call addFileToMonitor() for each configured json file (bep_build.json and
  * bep_test.json).
- * 
- * TODO refactor this such that the FileStream is just a one scan and done class, and implement the file
- * poller stuff in a subclass for those tools that want to monitor a file
  */
 public class BazelBuildEventsFileStream extends BazelBuildEventStream {
     private static final LogHelper LOG = LogHelper.log(BazelBuildEventsFileStream.class);
 
-    private int filePollerIntervalSeconds = 5;
-    private final List<MonitoredFile> monitoredFiles = new ArrayList<>();
-    private FilePoller filePoller = null;
+    protected final List<BEPMonitoredFile> monitoredFiles = new ArrayList<>();
 
     public BazelBuildEventsFileStream() {}
 
@@ -42,112 +40,62 @@ public class BazelBuildEventsFileStream extends BazelBuildEventStream {
 
     /**
      * Bazel supports output of BEP events to one or more files. For each BEP file you have configured for your
-     * workspace, add it here. The file does not need to exist. This helps in cases when the build has not yet run and
-     * the file has not been written yet. But this does mean that passing an incorrect File object will cause your
-     * events to be missed.
-     * <p>
-     * You must decide if the stream should parse the state of the BEP file when this stream is created. This might be
-     * correct behavior, but think about cases in which the user has not run the build in many days. The BEP file would
-     * contain build events from many days ago. If it would be odd for your app to react to build events that are many
-     * days old, set <i>parseOnStart</i> to false.
+     * workspace, you can add it here. The file does not need to exist. This helps in cases when the build has 
+     * not yet run and the file has not been written yet. But this does mean that passing an incorrect File object 
+     * will cause your events to be missed when you activate your stream.
      */
-    public void addFileToMonitor(File bepFile, boolean parseOnStart) {
-        MonitoredFile monitoredFile = new MonitoredFile();
+    public void addFileToMonitor(File bepFile) {
+        addFileToMonitor_Internal(bepFile);
+    }
+
+    @Override
+    public void activateStream() {
+        super.activateStream();
+        
+        for (BEPMonitoredFile bepFile : monitoredFiles) {
+            processFile(bepFile);
+        }
+    }
+
+    // INTERNAL
+
+    protected BEPMonitoredFile addFileToMonitor_Internal(File bepFile) {
+        BEPMonitoredFile monitoredFile = new BEPMonitoredFile();
         monitoredFile.file = bepFile;
 
         // set last mod to zero so we will parse the file on the first run
         monitoredFile.fileLastModifiedMS = 0L;
 
-        // but if caller does not want the initial state parsed, capture the current
-        // last mod
-        if (!parseOnStart && monitoredFile.file.exists()) {
-            monitoredFile.fileLastModifiedMS = monitoredFile.file.lastModified();
-        }
-
         // create the parser object
-        monitoredFile.bepFile = new BazelBuildEventsFileParser(bepFile);
+        monitoredFile.bepFile = new BEPFileParser(bepFile);
 
         monitoredFiles.add(monitoredFile);
+        
+        return monitoredFile;
     }
 
-    /**
-     * The stream will monitor the BEP json files for any changes, based on a polling interval.
-     */
-    public void setFilePollerIntervalSeconds(int seconds) {
-        filePollerIntervalSeconds = seconds;
-    }
-
-    @Override
-    public void activateStream() {
-        if (filePoller == null) {
-            filePoller = new FilePoller();
-            // let's go
-            new Thread(filePoller).start();
+    
+    protected void processFile(BEPMonitoredFile monitoredFile) {
+        if (!monitoredFile.file.exists()) {
+            // the monitored file does not exist yet (user needs to run a build?)
+            LOG.info("File [{}] does not exist yet. Run a build?", monitoredFile.file.getAbsolutePath());
+            return;
         }
-        super.activateStream();
-    }
 
-    // INTERNAL
+        // parse the file, but use the previous results (if this file has been scanned before) as a cache, 
+        // to avoid reparsing lines we have already parsed
+        BEPFileContents previousContent = monitoredFile.previousResults;
+        BEPFileParser bepFile = monitoredFile.bepFile;
+        BEPFileContents newContent = bepFile.readEvents("BazelBuildEventsFileStream", previousContent);
+        monitoredFile.previousResults = newContent;
 
-    /**
-     * Internal thread for polling the BEP files on an interval.
-     */
-    private class FilePoller implements Runnable {
-
-        @Override
-        public void run() {
-
-            while (true) {
-                try {
-                    Thread.sleep(filePollerIntervalSeconds * 1000);
-                } catch (InterruptedException ie) {}
-
-                if (paused) {
-                    // if still paused, just restart the loop
-                    continue;
-                }
-
-                for (MonitoredFile monitoredFile : monitoredFiles) {
-                    if (!monitoredFile.file.exists()) {
-                        // the monitored file does not exist yet (user needs to run a build?)
-                        LOG.info("File [{}] does not exist yet. Run a build?", monitoredFile.file.getAbsolutePath());
-                        continue;
-                    }
-
-                    // only re-parse the file if it has changed since the last iteration
-                    long currentLastMod = monitoredFile.file.lastModified();
-                    if (currentLastMod == monitoredFile.fileLastModifiedMS) {
-                        // the file hasn't changed since we last parsed it, bail
-                        LOG.info("FilePoller will not parse [{}] because it hasn't changed.", monitoredFile.file.getName());
-                        continue;
-                    }
-                    monitoredFile.fileLastModifiedMS = currentLastMod;
-
-                    // reparse the file, but use the previous results as a cache, to avoid reparsing lines we have already parsed
-                    BazelBuildEventsFileContents previousContent = monitoredFile.previousResults;
-                    BazelBuildEventsFileParser bepFile = monitoredFile.bepFile;
-                    BazelBuildEventsFileContents newContent =
-                            bepFile.readEvents("BazelBuildEventsFileStream", previousContent);
-                    monitoredFile.previousResults = newContent;
-
-                    // iterate through the newly found lines and send them to the subscribers
-                    for (BEPEvent event : newContent.events) {
-                        if (event.isProcessed()) {
-                            continue;
-                        }
-                        event.processed();
-                        publishEventToSubscribers(event);
-                    }
-                }
+        // iterate through the newly found lines and send them to the subscribers
+        for (BEPEvent event : newContent.events) {
+            if (event.isProcessed()) {
+                continue;
             }
+            event.processed();
+            publishEventToSubscribers(event);
         }
-
-    }
-
-    private static class MonitoredFile {
-        public File file;
-        public long fileLastModifiedMS = 0L;
-        public BazelBuildEventsFileParser bepFile;
-        public BazelBuildEventsFileContents previousResults;
     }
 }

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/BazelBuildEventsPollingFileStream.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/BazelBuildEventsPollingFileStream.java
@@ -1,0 +1,116 @@
+package com.salesforce.bazel.sdk.bep;
+
+import java.io.File;
+
+import com.salesforce.bazel.sdk.bep.file.BEPMonitoredFile;
+import com.salesforce.bazel.sdk.logging.LogHelper;
+
+/**
+ * Bazel build event protocol stream (BEP) for a Bazel workspace. A BEP stream allows you to monitor and react to build
+ * events emitted from Bazel. This implementation spawns a thread and actively polls one or more BEP files for new events.
+ * It is intelligent and will only reparse a file if the file modification time has changed.
+ * <p>
+ * Because this stream integrates with your builds with Bazel using BEP, this stream will work with command line builds
+ * but also with IDE builds.
+ * <p>
+ * After creation, you must start the stream by calling activateStream().
+ * <p>
+ * <b>NOTE:</b> This feature requires a configuration change to your Bazel workspace: you must add the following lines
+ * to your .bazelrc file to enable BEP:<br/>
+ * build --build_event_json_file bep_build.json<br/>
+ * test --build_event_json_file bep_test.json<br/>
+ * <p>
+ * In the above example, you must call addFileToMonitor() for each configured json file (bep_build.json and
+ * bep_test.json).
+ */
+public class BazelBuildEventsPollingFileStream extends BazelBuildEventsFileStream {
+    private static final LogHelper LOG = LogHelper.log(BazelBuildEventsPollingFileStream.class);
+
+    public int filePollerIntervalSeconds = 5;
+    private FilePoller filePoller = null;
+
+    public BazelBuildEventsPollingFileStream() {}
+
+    // PUBLIC API
+
+    /**
+     * Bazel supports output of BEP events to one or more files. For each BEP file you have configured for your
+     * workspace, add it here. The file does not need to exist. This helps in cases when the build has not yet run and
+     * the file has not been written yet. But this does mean that passing an incorrect File object will cause your
+     * events to be missed.
+     * <p>
+     * You must decide if the stream should parse the state of the BEP file when this stream is created. This might be
+     * correct behavior, but think about cases in which the user has not run the build in many days. The BEP file would
+     * contain build events from many days ago. If it would be odd for your app to react to build events that are many
+     * days old, set <i>parseOnStart</i> to false.
+     */
+    public void addFileToMonitor(File bepFile, boolean parseOnStart) {
+        BEPMonitoredFile monitoredFile = addFileToMonitor_Internal(bepFile);
+        
+        // if caller does not want the initial state parsed, capture the current last mod
+        if (!parseOnStart && monitoredFile.file.exists()) {
+            monitoredFile.fileLastModifiedMS = monitoredFile.file.lastModified();
+        }
+    }
+
+    /**
+     * The stream will monitor the BEP json files for any changes, based on a polling interval.
+     */
+    public void setFilePollerIntervalSeconds(int seconds) {
+        filePollerIntervalSeconds = seconds;
+    }
+
+    @Override
+    public void activateStream() {
+        if (filePoller == null) {
+            filePoller = new FilePoller();
+            // let's go
+            new Thread(filePoller).start();
+        }
+        super.activateStream();
+    }
+
+    // INTERNAL
+
+    /**
+     * Internal thread for polling the BEP files on an interval.
+     */
+    private class FilePoller implements Runnable {
+
+        @Override
+        public void run() {
+
+            while (true) {
+                try {
+                    Thread.sleep(filePollerIntervalSeconds * 1000);
+                } catch (InterruptedException ie) {}
+
+                if (paused) {
+                    // if still paused, just restart the loop
+                    continue;
+                }
+
+                for (BEPMonitoredFile monitoredFile : monitoredFiles) {
+                    if (!monitoredFile.file.exists()) {
+                        // the monitored file does not exist yet (user needs to run a build?)
+                        LOG.info("File [{}] does not exist yet. Run a build?", monitoredFile.file.getAbsolutePath());
+                        continue;
+                    }
+
+                    // only re-parse the file if it has changed since the last iteration
+                    long currentLastMod = monitoredFile.file.lastModified();
+                    if (currentLastMod == monitoredFile.fileLastModifiedMS) {
+                        // the file hasn't changed since we last parsed it, bail
+                        LOG.info("FilePoller will not parse [{}] because it hasn't changed.", monitoredFile.file.getName());
+                        continue;
+                    }
+                    monitoredFile.fileLastModifiedMS = currentLastMod;
+
+                    // parse the file and publish events
+                    processFile(monitoredFile);
+                }
+            }
+        }
+
+    }
+}

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPFileContents.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPFileContents.java
@@ -9,7 +9,7 @@ import com.salesforce.bazel.sdk.bep.event.BEPEvent;
 /**
  * Contents of a single pass parsing of a BEP json file.
  */
-public class BazelBuildEventsFileContents {
+public class BEPFileContents {
     public List<BEPEvent> events = new ArrayList<>();
 
     // commonly needed quick lookups, if any event has these fields set, we set the flag on the result

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPFileParser.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPFileParser.java
@@ -24,8 +24,8 @@ import com.salesforce.bazel.sdk.logging.LogHelper;
  * <p>
  * <a href="https://docs.bazel.build/versions/master/build-event-protocol.html">BEP Documentation</a>
  */
-public class BazelBuildEventsFileParser {
-    static final LogHelper LOG = LogHelper.log(BazelBuildEventsFileParser.class);
+public class BEPFileParser {
+    static final LogHelper LOG = LogHelper.log(BEPFileParser.class);
 
     private final File bepFile;
 
@@ -36,16 +36,16 @@ public class BazelBuildEventsFileParser {
      * Creates the BazelBuildEventsFile for a File. Note that the File may not exist. This can happen if this
      * configuration happens prior to a build with the configuration setting enabled.
      */
-    public BazelBuildEventsFileParser(File bepFile) {
+    public BEPFileParser(File bepFile) {
         this.bepFile = bepFile;
     }
 
     /**
      * Reads the BEP json file, and returns a results object with the parsed events.
      */
-    public BazelBuildEventsFileContents readEvents(String callerForLog, BazelBuildEventsFileContents previousContents) {
+    public BEPFileContents readEvents(String callerForLog, BEPFileContents previousContents) {
 
-        BazelBuildEventsFileContents result = new BazelBuildEventsFileContents();
+        BEPFileContents result = new BEPFileContents();
         int eventIndex = 0;
 
         if (!bepFile.exists()) {
@@ -131,9 +131,9 @@ public class BazelBuildEventsFileParser {
     // simple manual test client
     public static void main(String[] args) {
         File bepFile = new File("/tmp/bep_build_success.json");
-        BazelBuildEventsFileParser bazelEventsFile = new BazelBuildEventsFileParser(bepFile);
+        BEPFileParser bazelEventsFile = new BEPFileParser(bepFile);
 
-        BazelBuildEventsFileContents result = bazelEventsFile.readEvents("testapp", null);
+        BEPFileContents result = bazelEventsFile.readEvents("testapp", null);
 
         for (BEPEvent event : result.events) {
             LOG.info(event.toString());

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPMonitoredFile.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPMonitoredFile.java
@@ -1,0 +1,13 @@
+package com.salesforce.bazel.sdk.bep.file;
+
+import java.io.File;
+
+/**
+ * A file that is monitored by a file stream.
+ */
+public class BEPMonitoredFile {
+    public File file;
+    public long fileLastModifiedMS = 0L;
+    public BEPFileParser bepFile;
+    public BEPFileContents previousResults;
+}


### PR DESCRIPTION
Make the FileStream a real class for tools that just need to process an existing BEP file, and the PollingFileStream a specialization that monitors BEP files for new events.