### PR TITLE
incremental improvement of path support

### DIFF
--- a/examples/src/main/java/com/salesforce/bazel/app/analyzer/BazelAnalyzerApp.java
+++ b/examples/src/main/java/com/salesforce/bazel/app/analyzer/BazelAnalyzerApp.java
@@ -46,7 +46,7 @@ import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageInfo;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 import com.salesforce.bazel.sdk.model.BazelWorkspace;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.BazelWorkspaceScanner;
 import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
 import com.salesforce.bazel.sdk.workspace.ProjectOrderResolver;

--- a/examples/src/main/java/com/salesforce/bazel/app/builder/BazelBuilderApp.java
+++ b/examples/src/main/java/com/salesforce/bazel/app/builder/BazelBuilderApp.java
@@ -12,7 +12,7 @@ import com.salesforce.bazel.sdk.command.shell.ShellCommandBuilder;
 import com.salesforce.bazel.sdk.console.CommandConsoleFactory;
 import com.salesforce.bazel.sdk.console.StandardCommandConsoleFactory;
 import com.salesforce.bazel.sdk.model.BazelProblem;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * This app, as a tool, is not useful. It simply uses the Bazel Java SDK to run a build on a Bazel workspace. In effect,

--- a/examples/src/main/java/com/salesforce/bazel/app/indexer/JvmCodeIndexerApp.java
+++ b/examples/src/main/java/com/salesforce/bazel/app/indexer/JvmCodeIndexerApp.java
@@ -30,7 +30,7 @@ import com.salesforce.bazel.sdk.index.jvm.JvmCodeIndex;
 import com.salesforce.bazel.sdk.index.jvm.jar.JarIdentiferResolver;
 import com.salesforce.bazel.sdk.index.jvm.jar.JavaJarCrawler;
 import com.salesforce.bazel.sdk.index.source.SourceFileCrawler;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Indexer for building a JVM type index from nested sets of directories. Supports indexing both source files, and
@@ -104,7 +104,7 @@ public class JvmCodeIndexerApp {
 
         if (externalJarRoot.contains("bazel-out")) {
             if (externalJarRoot.endsWith("bin")) {
-                externalJarRoot = BazelPathHelper.osSeps(externalJarRoot + "/" + "external"); // $SLASH_OK
+                externalJarRoot = BazelPathHelper.osSeps(externalJarRoot + BazelPathHelper.UNIX_SLASH + "external");
             }
         }
         File externalJarRootFile = new File(externalJarRoot);

--- a/examples/src/main/java/com/salesforce/bazel/app/subscriber/BazelSubscriberApp.java
+++ b/examples/src/main/java/com/salesforce/bazel/app/subscriber/BazelSubscriberApp.java
@@ -5,7 +5,7 @@ import java.io.File;
 import com.salesforce.bazel.sdk.bep.BazelBuildEventSubscriber;
 import com.salesforce.bazel.sdk.bep.BazelBuildEventsPollingFileStream;
 import com.salesforce.bazel.sdk.bep.event.BEPProgressEvent;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * This app uses the Bazel Java SDK to monitor builds in a Bazel workspace on your machine. It hooks into build activity

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/MockCommandSimulatedOutputMatcher.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/MockCommandSimulatedOutputMatcher.java
@@ -1,5 +1,7 @@
 package com.salesforce.bazel.sdk.command.test;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Filter that enables Bazel command output to be associated with a particular command. By providing a list of these,
  * you can make sure that the output lines are only returned to the caller if all matchers return true.
@@ -12,8 +14,9 @@ public class MockCommandSimulatedOutputMatcher {
         matchArgIndex = index;
         matchArgRegex = regex;
 
-        if (matchArgRegex.contains("\\")) {
-            matchArgRegex = matchArgRegex.replace("\\", "\\\\");
+        if (matchArgRegex.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
+            matchArgRegex =
+                    matchArgRegex.replace(BazelPathHelper.WINDOWS_BACKSLASH, BazelPathHelper.WINDOWS_BACKSLASH_REGEX);
         }
     }
 }

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestAspectFileCreator.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestAspectFileCreator.java
@@ -5,7 +5,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Writes json files to the Bazel output file system that mimic what is written by the Bazel aspects. Each json file
@@ -51,7 +51,7 @@ public class TestAspectFileCreator {
      * @return the absolute File path to the file
      */
     static String createJavaAspectFileForMavenJar(File outputBase, String mavenJarName, String actualJarNameNoSuffix) {
-        String externalName = "external" + "/" + mavenJarName; // $SLASH_OK
+        String externalName = "external" + BazelPathHelper.UNIX_SLASH + mavenJarName;
         String dependencies = null;
         List<String> sources = null;
         String mainClass = null;
@@ -218,7 +218,7 @@ public class TestAspectFileCreator {
         if (sources != null) {
             for (String source : sources) {
                 sb.append("    \""); // $SLASH_OK: escape char
-                source = source.replace("\\", "\\\\"); // hack because Windows paths need to be json escaped
+                source = source.replace(BazelPathHelper.WINDOWS_BACKSLASH, BazelPathHelper.WINDOWS_BACKSLASH_REGEX); // hack because Windows paths need to be json escaped
                 sb.append(source);
                 sb.append("\",\n"); // $SLASH_OK: line continue
             }

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Descriptor for a manufactured bazel package in a test workspace.
  */
@@ -26,7 +28,7 @@ public class TestBazelPackageDescriptor {
     public TestBazelPackageDescriptor(TestBazelWorkspaceDescriptor parentWorkspace, String packagePath,
             String packageName, File diskLocation) {
 
-        if (packagePath.contains("\\")) {
+        if (packagePath.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
             // Windows bug, someone passed in a Windows path
             throw new IllegalArgumentException(
                     "Windows filesystem path passed to TestBazelPackageDescriptor instead of the Bazel package path: "

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Utility class to generate a Bazel workspace and other artifacts on the filesystem. As of this writing, the workspace

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
@@ -5,7 +5,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Map;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class TestJavaRuleCreator {
     public static void createJavaBuildFile(TestBazelWorkspaceDescriptor workspaceDescriptor, File buildFile,

--- a/sdk/bazel-java-sdk/BUILD
+++ b/sdk/bazel-java-sdk/BUILD
@@ -123,60 +123,66 @@ java_test(
 java_test(
     name = "BazelLabelTest",
     srcs = [
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
         "src/test/java/com/salesforce/bazel/sdk/model/BazelLabelTest.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
     ],
 )
 
 java_test(
     name = "BazelLabelUtilTest",
     srcs = [
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java",
         "src/test/java/com/salesforce/bazel/sdk/model/BazelLabelUtilTest.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
     ],
 )
 
 java_test(
     name = "BazelProblemTest",
     srcs = [
-        "src/main/java/com/salesforce/bazel/sdk/logging/BasicLoggerFacade.java",
-        "src/main/java/com/salesforce/bazel/sdk/logging/LogHelper.java",
-        "src/main/java/com/salesforce/bazel/sdk/logging/LoggerFacade.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java",
         "src/test/java/com/salesforce/bazel/sdk/model/BazelProblemTest.java",
-        "src/main/java/com/salesforce/bazel/sdk/util/BazelPathHelper.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
     ],
 )
 
 java_test(
     name = "BazelOutputDirectoryBuilderTest",
     srcs = [
-        "src/main/java/com/salesforce/bazel/sdk/logging/BasicLoggerFacade.java",
-        "src/main/java/com/salesforce/bazel/sdk/logging/LogHelper.java",
-        "src/main/java/com/salesforce/bazel/sdk/logging/LoggerFacade.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelTargetKind.java",
-        "src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java",
         "src/test/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java",
-        "src/main/java/com/salesforce/bazel/sdk/util/BazelPathHelper.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
     ],
 )
 
 java_test(
     name = "BazelOutputParserTest",
     srcs = [
-        "src/main/java/com/salesforce/bazel/sdk/logging/BasicLoggerFacade.java",
-        "src/main/java/com/salesforce/bazel/sdk/logging/LogHelper.java",
-        "src/main/java/com/salesforce/bazel/sdk/logging/LoggerFacade.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java",
-        "src/main/java/com/salesforce/bazel/sdk/command/BazelOutputParser.java",
         "src/test/java/com/salesforce/bazel/sdk/command/BazelOutputParserTest.java",
-        "src/main/java/com/salesforce/bazel/sdk/util/BazelPathHelper.java",
     ],
-    deps = [],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
+    ],
 )
 
 java_test(
@@ -205,17 +211,21 @@ java_test(
 java_test(
     name = "BazelPackageInfoTest",
     srcs = [
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java",
         "src/test/java/com/salesforce/bazel/sdk/model/BazelPackageInfoTest.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelPackageLocation.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
     ],
 )
 
 java_test(
     name = "LogHelperTest",
-    srcs = ["src/test/java/com/salesforce/bazel/sdk/logging/CaptureLoggerFacade.java",
-            "src/test/java/com/salesforce/bazel/sdk/logging/LogHelperTest.java"],
+    srcs = [
+        "src/test/java/com/salesforce/bazel/sdk/logging/CaptureLoggerFacade.java",
+        "src/test/java/com/salesforce/bazel/sdk/logging/LogHelperTest.java"],
     deps = [
         ":bazel-java-sdk",
 
@@ -227,12 +237,13 @@ java_test(
 java_test(
     name = "ProjectViewTest",
     srcs = [
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/sdk/model/BazelPackageLocation.java",
-        "src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java",
-        "src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java",
         "src/test/java/com/salesforce/bazel/sdk/project/ProjectViewTest.java",
-        "src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
     ],
 )
 

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
@@ -34,14 +34,10 @@
 package com.salesforce.bazel.sdk.command;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Knows how to build paths to various files under bazel output directories (bazel-bin etc)
- *
- * @author stoens
- * @since summer 2019
- *
  */
 public class BazelOutputDirectoryBuilder {
 
@@ -52,10 +48,15 @@ public class BazelOutputDirectoryBuilder {
      */
     public String getRunScriptPath(BazelLabel label) {
         StringBuilder sb = new StringBuilder();
-        sb.append("bazel-bin/");
+        sb.append("bazel-bin");
+        sb.append(BazelPathHelper.UNIX_SLASH);
         sb.append(label.getPackagePath());
-        sb.append("/");
+        sb.append(BazelPathHelper.UNIX_SLASH);
         sb.append(label.getTargetName());
-        return BazelPathHelper.osSeps(sb.toString());
+
+        // generate the String, converting to Windows style path if necessary
+        String path = BazelPathHelper.osSeps(sb.toString());
+
+        return path;
     }
 }

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
@@ -33,6 +33,7 @@ import com.salesforce.bazel.sdk.index.jvm.JvmCodeIndex;
 import com.salesforce.bazel.sdk.index.model.ClassIdentifier;
 import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Crawler that descends into nested directories of jar files and adds found files to the index.
@@ -144,7 +145,7 @@ public class JavaJarCrawler {
                 continue;
             }
             // convert path / into . to form the legal package name, and trim the .class off the end
-            fqClassname = fqClassname.replace("/", ".");
+            fqClassname = fqClassname.replace(BazelPathHelper.JAR_SLASH, ".");
             fqClassname = fqClassname.substring(0, fqClassname.length() - 6);
             LOG.debug("Indexer found classname: {} in jar {}", fqClassname, jarId.locationIdentifier);
 

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/source/SourceFileCrawler.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/source/SourceFileCrawler.java
@@ -32,7 +32,7 @@ import com.salesforce.bazel.sdk.index.CodeIndex;
 import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
 import com.salesforce.bazel.sdk.index.model.CodeLocationIdentifier;
 import com.salesforce.bazel.sdk.logging.LogHelper;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Crawler that descends into nested directories of source files and adds found files to the index.
@@ -105,8 +105,10 @@ public class SourceFileCrawler {
                         }
                         String childRelative = candidateFile.getName();
                         if (!relativePathToClosestArtifact.isEmpty()) {
-                            childRelative = BazelPathHelper
-                                    .osSeps(relativePathToClosestArtifact + "/" + candidateFile.getName()); // $SLASH_OK
+                            childRelative = relativePathToClosestArtifact + BazelPathHelper.UNIX_SLASH
+                                    + candidateFile.getName();
+                            // convert to Windows path if necessary
+                            childRelative = BazelPathHelper.osSeps(childRelative);
                         }
                         indexRecur(candidateFile, childRelative, closestArtifactLocationDescriptor, false);
                     } else if (candidateFile.canRead()) {

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
@@ -33,6 +33,8 @@
  */
 package com.salesforce.bazel.sdk.model;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Answers to everything you've always wanted to ask a Bazel Label.
  * </p>
@@ -63,7 +65,7 @@ public class BazelLabel {
         if (label == null) {
             throw new IllegalArgumentException("label cannot be null");
         }
-        if (label.contains("\\")) {
+        if (label.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
             // the caller is passing us a label with \ as separators, probably a bug due to Windows paths
             throw new IllegalArgumentException(
                     "Label [" + label + "] has Windows style path delimeters. Bazel paths always have / delimiters");
@@ -144,7 +146,7 @@ public class BazelLabel {
         int i = packagePath.lastIndexOf("...");
         if (i != -1) {
             packagePath = packagePath.substring(0, i);
-            if (packagePath.endsWith("/")) { // $SLASH_OK: bazel path
+            if (packagePath.endsWith(BazelPathHelper.BAZEL_SLASH)) {
                 packagePath = packagePath.substring(0, packagePath.length() - 1);
             }
         } else {
@@ -179,7 +181,7 @@ public class BazelLabel {
      */
     public String getPackageName() {
         String packagePath = getPackagePath();
-        int i = packagePath.lastIndexOf("/"); // $SLASH_OK: bazel path
+        int i = packagePath.lastIndexOf(BazelPathHelper.BAZEL_SLASH);
         return i == -1 ? packagePath : packagePath.substring(i + 1);
     }
 
@@ -215,7 +217,7 @@ public class BazelLabel {
         if (targetName == null) {
             return null;
         }
-        int i = targetName.lastIndexOf("/"); // $SLASH_OK: bazel path
+        int i = targetName.lastIndexOf(BazelPathHelper.BAZEL_SLASH);
         if (i != -1) {
             return targetName.substring(i + 1); // ok because target name cannot end with slash
         }
@@ -270,7 +272,7 @@ public class BazelLabel {
             throw new IllegalAccessError(path);
         }
         path = path.trim();
-        if (path.endsWith("/")) { // $SLASH_OK: bazel path
+        if (path.endsWith(BazelPathHelper.BAZEL_SLASH)) {
             path = path.substring(0, path.length() - 1);
         }
         return path;
@@ -298,7 +300,7 @@ public class BazelLabel {
         if (label.endsWith(":")) {
             throw new IllegalArgumentException(label);
         }
-        if (label.endsWith("/")) { // $SLASH_OK: bazel path
+        if (label.endsWith(BazelPathHelper.BAZEL_SLASH)) {
             throw new IllegalArgumentException(label);
         }
         if (label.equals("//")) {
@@ -307,7 +309,7 @@ public class BazelLabel {
         if (label.startsWith("//")) {
             label = label.substring(2);
         }
-        if (label.startsWith("/")) { // $SLASH_OK: bazel path
+        if (label.startsWith(BazelPathHelper.BAZEL_SLASH)) {
             label = label.substring(1);
         }
         return label;

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
@@ -40,6 +40,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Model class for a Bazel Java package. It is a node in a tree of the hierarchy of packages. The root node in this tree
  * is the directory which contains the WORKSPACE file, and is a special case in that it does not typically represent
@@ -315,19 +317,19 @@ public class BazelPackageInfo implements BazelPackageLocation {
         }
 
         // split the file system path by OS path separator
-        String regex = "/";
-        if (File.separator.equals("\\")) {
-            regex = "\\\\";
+        String regex = BazelPathHelper.UNIX_SLASH;
+        if (File.separator.equals(BazelPathHelper.WINDOWS_BACKSLASH)) {
+            regex = BazelPathHelper.WINDOWS_BACKSLASH_REGEX;
         }
         String[] pathElements = relativeWorkspacePath.split(regex);
 
         // assemble the path elements into a proper Bazel package name
-        String name = "/"; // $SLASH_OK: bazel path
+        String name = BazelPathHelper.BAZEL_SLASH;
         for (String e : pathElements) {
             if (e.isEmpty()) {
                 continue;
             }
-            name = name + "/" + e; // $SLASH_OK: bazel path
+            name = name + BazelPathHelper.BAZEL_SLASH + e;
         }
 
         // set computedPackageName only when done computing it, to avoid threading issues
@@ -348,7 +350,7 @@ public class BazelPackageInfo implements BazelPackageLocation {
         if (computedPackageNameLastSegment != null) {
             return computedPackageNameLastSegment;
         }
-        int lastSlash = computedPackageName.lastIndexOf("/"); // $SLASH_OK: bazel path
+        int lastSlash = computedPackageName.lastIndexOf(BazelPathHelper.BAZEL_SLASH);
         if (lastSlash == -1) {
             computedPackageNameLastSegment = "";
             return computedPackageNameLastSegment;

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java
@@ -37,7 +37,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Objects;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * A wrapper for a Bazel logical "problem" (error/warning).
@@ -147,7 +147,7 @@ public class BazelProblem {
 
     private String getRelativeResourcePath(BazelLabel label) {
         String bazelPackagePath = label.getPackagePath();
-        String relativeFilePath = BazelPathHelper.osSeps(bazelPackagePath + "/");
+        String relativeFilePath = BazelPathHelper.osSeps(bazelPackagePath + BazelPathHelper.UNIX_SLASH);
         if (resourcePath.startsWith(relativeFilePath) && (resourcePath.length() > (relativeFilePath.length()))) {
             return File.separator + resourcePath.substring(relativeFilePath.length());
         }

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/InMemoryBazelPackageLocation.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/InMemoryBazelPackageLocation.java
@@ -26,7 +26,7 @@ public class InMemoryBazelPackageLocation implements BazelPackageLocation {
             this.path = path;
         }
         this.lastSegment = "";
-        int lastSlash = path.indexOf("/");
+        int lastSlash = path.indexOf(File.separator);
         if (lastSlash > 0) {
             this.lastSegment = path.substring(lastSlash + 1);
         }

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
@@ -1,4 +1,4 @@
-package com.salesforce.bazel.sdk.util;
+package com.salesforce.bazel.sdk.path;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,6 +10,29 @@ import com.salesforce.bazel.sdk.logging.LogHelper;
  */
 public class BazelPathHelper {
     private static final LogHelper LOG = LogHelper.log(BazelPathHelper.class);
+
+    // Slash character for Bazel paths; this is provided as a constant to help code searches
+    // for Bazel specific code. 
+    public static final String BAZEL_SLASH = "/";
+
+    // Slash character for unix file paths; this is provided as a constant to help code searches
+    // for Unix specific code. 
+    public static final String UNIX_SLASH = "/";
+
+    // Backslash character; this is provided as a constant to help code searches
+    // for Windows specific code. There are two backslash characters because Java 
+    // requires a leading backslash to encode a backslash
+    public static final String WINDOWS_BACKSLASH = "\\";
+
+    // Regex pattern to use to look for a single backslash character in a path
+    // why 4? 
+    // Regex needs a double \ to escape backslash in the matcher (1+1=2)
+    // Java requires a backslash to encode a backslash in the String (2x2=4)
+    public static final String WINDOWS_BACKSLASH_REGEX = "\\\\";
+
+    // Slash character for file paths in jar files; this is provided as a constant to help code searches
+    // for Jar specific code. 
+    public static final String JAR_SLASH = "/";
 
     /**
      * Primary feature toggle. isUnix is true for all platforms except Windows.
@@ -74,10 +97,9 @@ public class BazelPathHelper {
 
     public static String osSepRegex() {
         if (isUnix) {
-            return "/";
+            return UNIX_SLASH;
         }
-        // why 4? Java requires 2 backslashes to encode the String, and regex needs a double \ to escape backslash in the matcher
-        return "\\\\";
+        return WINDOWS_BACKSLASH_REGEX;
     }
 
     /**
@@ -86,7 +108,7 @@ public class BazelPathHelper {
     public static String osSeps(String unixStylePath) {
         String path = unixStylePath;
         if (!isUnix) {
-            path = unixStylePath.replace("/", "\\");
+            path = unixStylePath.replace(UNIX_SLASH, WINDOWS_BACKSLASH);
         }
         return path;
     }
@@ -98,7 +120,7 @@ public class BazelPathHelper {
     public static String osSepsEscaped(String unixStylePath) {
         String path = unixStylePath;
         if (!isUnix) {
-            path = unixStylePath.replace("/", "\\\\");
+            path = unixStylePath.replace(UNIX_SLASH, WINDOWS_BACKSLASH);
         }
         return path;
     }
@@ -109,7 +131,7 @@ public class BazelPathHelper {
     public static String bazelLabelSeps(String fsPath) {
         String path = fsPath;
         if (!isUnix) {
-            path = fsPath.replace("\\", "/");
+            path = fsPath.replace(WINDOWS_BACKSLASH, UNIX_SLASH);
         }
         return path;
     }

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.Set;
 
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.util.BazelConstants;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
 import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
 
 /**

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/aspect/AspectOutputJarsTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/aspect/AspectOutputJarsTest.java
@@ -7,7 +7,7 @@ import org.json.simple.JSONObject;
 import org.junit.Test;
 
 import com.salesforce.bazel.sdk.aspect.jvm.JVMAspectOutputJarSet;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class AspectOutputJarsTest {
 

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
@@ -48,7 +48,7 @@ import org.junit.Test;
 
 import com.salesforce.bazel.sdk.init.JvmRuleInit;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class AspectTargetInfosTest {
 

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
@@ -42,7 +42,7 @@ import com.salesforce.bazel.sdk.command.test.TestBazelCommandEnvironmentFactory;
 import com.salesforce.bazel.sdk.init.JvmRuleInit;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceDescriptor;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
 

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class BazelOutputDirectoryBuilderTest {
 

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelTest.java
@@ -43,6 +43,8 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 public class BazelLabelTest {
 
     @Test
@@ -209,7 +211,7 @@ public class BazelLabelTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidLabel_trailingSlash() {
-        new BazelLabel("/"); // $SLASH_OK bazel path
+        new BazelLabel(BazelPathHelper.BAZEL_SLASH);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelProblemTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelProblemTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class BazelProblemTest {
 

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelWorkspaceTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelWorkspaceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandOptions;
 import com.salesforce.bazel.sdk.model.test.MockBazelWorkspaceMetadataStrategy;
 import com.salesforce.bazel.sdk.model.test.MockOperatingEnvironmentDetectionStrategy;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class BazelWorkspaceTest {
 


### PR DESCRIPTION
Work towards #4 which is to use classes to explicitly model paths such that we don't introduce windows bugs by mistake. This PR just adds constants so that "/" and "\\" patterns are searchable in the code base.

Lots of diffs because I moved BazelPathHelper into a new package.