### PR TITLE
allow the dependency graph impl to be pluggable

### DIFF
--- a/examples/src/main/java/com/salesforce/bazel/app/analyzer/BazelAnalyzerApp.java
+++ b/examples/src/main/java/com/salesforce/bazel/app/analyzer/BazelAnalyzerApp.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.salesforce.bazel.sdk.aspect.AspectDependencyGraphBuilder;
+import com.salesforce.bazel.sdk.aspect.AspectDependencyGraphFactory;
 import com.salesforce.bazel.sdk.aspect.AspectTargetInfo;
 import com.salesforce.bazel.sdk.aspect.AspectTargetInfos;
 import com.salesforce.bazel.sdk.aspect.BazelAspectLocation;
@@ -41,11 +41,11 @@ import com.salesforce.bazel.sdk.command.shell.ShellCommandBuilder;
 import com.salesforce.bazel.sdk.console.CommandConsoleFactory;
 import com.salesforce.bazel.sdk.console.StandardCommandConsoleFactory;
 import com.salesforce.bazel.sdk.init.JvmRuleInit;
-import com.salesforce.bazel.sdk.model.BazelDependencyGraph;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageInfo;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 import com.salesforce.bazel.sdk.model.BazelWorkspace;
+import com.salesforce.bazel.sdk.model.graph.BazelDependencyGraph;
 import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.BazelWorkspaceScanner;
 import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
@@ -141,7 +141,7 @@ public class BazelAnalyzerApp {
         }
 
         // use the dependency data to interact with the dependency graph (print root labels)
-        BazelDependencyGraph depGraph = AspectDependencyGraphBuilder.build(aspects, false);
+        BazelDependencyGraph depGraph = AspectDependencyGraphFactory.build(aspects, false);
         Set<String> rootLabels = depGraph.getRootLabels();
         printRootLabels(rootLabels);
 

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/MockCommand.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/MockCommand.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 
 import com.salesforce.bazel.sdk.command.BazelProcessBuilder;
 import com.salesforce.bazel.sdk.command.Command;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
 import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
@@ -147,7 +148,7 @@ public class MockCommand implements Command {
         }
         String packageLabel = target;
         String ruleName = "*";
-        int colonIndex = target.indexOf(":");
+        int colonIndex = target.indexOf(BazelPathHelper.BAZEL_COLON);
         if (colonIndex >= 0) {
             packageLabel = target.substring(0, colonIndex);
             ruleName = target.substring(colonIndex + 1);

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelTargetDescriptor.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelTargetDescriptor.java
@@ -1,5 +1,7 @@
 package com.salesforce.bazel.sdk.workspace.test;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Descriptor for a manufactured target (java_library, java_test, etc) in a manufactured bazel package in a test
  * workspace.
@@ -19,7 +21,7 @@ public class TestBazelTargetDescriptor {
 
     public TestBazelTargetDescriptor(TestBazelPackageDescriptor parentPackage, String targetName, String targetType) {
         this.parentPackage = parentPackage;
-        this.targetPath = parentPackage.packagePath + ":" + targetName;
+        this.targetPath = parentPackage.packagePath + BazelPathHelper.BAZEL_COLON + targetName;
         this.targetName = targetName;
         this.targetType = targetType;
 

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
@@ -191,7 +191,7 @@ public class TestBazelWorkspaceFactory {
                 packageAspectFiles.add(previousAspectFilePath);
             }
             // now save off our current lib target to add to the next
-            previousJavaLibTarget = packageRelativeBazelPath + ":" + packageName;
+            previousJavaLibTarget = packageRelativeBazelPath + BazelPathHelper.BAZEL_COLON + packageName;
             previousAspectFilePath = aspectFilePath_mainsource;
 
             // write fake jar files to the filesystem for this project

--- a/sdk/bazel-java-sdk/BUILD
+++ b/sdk/bazel-java-sdk/BUILD
@@ -119,6 +119,32 @@ java_test(
     ],
 )
 
+java_test(
+    name = "BazelDependencyGraphFactoryTest",
+    srcs = [
+        "src/test/java/com/salesforce/bazel/sdk/graph/BazelDependencyGraphFactoryTest.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_mockito_mockito_core",
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
+    ],
+)
+
+java_test(
+    name = "InMemoryDependencyGraphTest",
+    srcs = [
+        "src/test/java/com/salesforce/bazel/sdk/graph/InMemoryDependencyGraphTest.java",
+    ],
+    deps = [
+        ":bazel-java-sdk",
+
+        "@maven//:org_hamcrest_hamcrest_core",
+        "@maven//:junit_junit",
+    ],
+)
 
 java_test(
     name = "BazelLabelTest",

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectDependencyGraphFactory.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectDependencyGraphFactory.java
@@ -1,13 +1,16 @@
 package com.salesforce.bazel.sdk.aspect;
 
+import java.util.HashMap;
 import java.util.List;
 
-import com.salesforce.bazel.sdk.model.BazelDependencyGraph;
+import com.salesforce.bazel.sdk.model.graph.BazelDependencyGraph;
+import com.salesforce.bazel.sdk.model.graph.BazelDependencyGraphFactory;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
- * Builder that uses the set of aspect infos generated for a workspace to construct the dependency graph.
+ * Factory that uses the set of aspect infos generated for a workspace to construct the dependency graph.
  */
-public class AspectDependencyGraphBuilder {
+public class AspectDependencyGraphFactory {
 
     /**
      * Builds the dependency graph using the data collected by running aspects. It is typical that the list of aspects
@@ -18,7 +21,11 @@ public class AspectDependencyGraphBuilder {
      * edge in between two packages if any target in package A depends on any target in package B.
      */
     public static BazelDependencyGraph build(AspectTargetInfos aspects, boolean includeTarget) {
-        BazelDependencyGraph graph = new BazelDependencyGraph();
+        BazelDependencyGraph graph = BazelDependencyGraphFactory.build("AspectDependencyGraphFactory", new HashMap<>());
+
+        // TODO the stripTargetFromLabel invocations here need to be removed in order for us to solve the
+        // the cyclical dependency problems tracked by https://github.com/salesforce/bazel-java-sdk/issues/23
+        // the InMemoryDependencyGraph will also need to be updated to support target level edges
 
         for (AspectTargetInfo info : aspects.getTargetInfos()) {
             String sourceLabel = info.getLabel();
@@ -48,7 +55,7 @@ public class AspectDependencyGraphBuilder {
             // ex:  @maven//:junit_junit
             return label;
         }
-        int colonIndex = label.lastIndexOf(":");
+        int colonIndex = label.lastIndexOf(BazelPathHelper.BAZEL_COLON);
         if (colonIndex > 0) {
             label = label.substring(0, colonIndex);
         }

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
@@ -88,7 +88,7 @@ public class BazelLabel {
      * example: "a/b/c" and "my-target-name".
      */
     public BazelLabel(String packagePath, String targetName) {
-        this(sanitizePackagePath(packagePath) + ":" + sanitizeTargetName(targetName));
+        this(sanitizePackagePath(packagePath) + BazelPathHelper.BAZEL_COLON + sanitizeTargetName(targetName));
     }
 
     /**
@@ -119,7 +119,7 @@ public class BazelLabel {
         if (!isConcrete()) {
             return false;
         }
-        int i = localLabelPart.lastIndexOf(":");
+        int i = localLabelPart.lastIndexOf(BazelPathHelper.BAZEL_COLON);
         return i == -1;
     }
 
@@ -150,7 +150,7 @@ public class BazelLabel {
                 packagePath = packagePath.substring(0, packagePath.length() - 1);
             }
         } else {
-            i = localLabelPart.lastIndexOf(":");
+            i = localLabelPart.lastIndexOf(BazelPathHelper.BAZEL_COLON);
             if (i != -1) {
                 packagePath = packagePath.substring(0, i);
             }
@@ -197,7 +197,7 @@ public class BazelLabel {
         if (isPackageDefault()) {
             return getPackageName();
         } else {
-            int i = localLabelPart.lastIndexOf(":");
+            int i = localLabelPart.lastIndexOf(BazelPathHelper.BAZEL_COLON);
             // label cannot end with ":", so this is ok
             return localLabelPart.substring(i + 1);
         }
@@ -283,7 +283,7 @@ public class BazelLabel {
             throw new IllegalArgumentException(target);
         }
         target = target.trim();
-        if (target.startsWith(":")) {
+        if (target.startsWith(BazelPathHelper.BAZEL_COLON)) {
             target = target.substring(1);
         }
         return target;
@@ -297,7 +297,7 @@ public class BazelLabel {
         if (label.length() == 0) {
             throw new IllegalArgumentException(label);
         }
-        if (label.endsWith(":")) {
+        if (label.endsWith(BazelPathHelper.BAZEL_COLON)) {
             throw new IllegalArgumentException(label);
         }
         if (label.endsWith(BazelPathHelper.BAZEL_SLASH)) {

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/BazelDependencyGraph.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/BazelDependencyGraph.java
@@ -1,0 +1,132 @@
+package com.salesforce.bazel.sdk.model.graph;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+
+public abstract class BazelDependencyGraph {
+
+    // CONSTRUCTION
+
+    /**
+     * Makes a dependency from source -> dep at the package level. For some use cases, package level dependencies are
+     * sufficient (//a/b/c), but in other cases target level dependencies are needed (//a/b/c:d). The caller of this
+     * method should provide as much detail as is available.
+     *
+     * @param sourceLabel
+     *            the label for the source package (e.g. //a/b/c or //a/b/c:d)
+     * @param depLabel
+     *            the label for the depended-on package (e.g. //foo or //foo:bar)
+     */
+    public abstract void addDependency(String sourceLabel, String depLabel);
+
+    // LOOKUPS
+
+    /**
+     * Provides a map for tracking forward deps. The key is the label as a string, and the value is the set of
+     * dependencies (as labels) for the source.
+     */
+    public abstract Map<String, Set<String>> getDependsOnMap();
+
+    /**
+     * Provides a map for tracking reverse deps. The key is the label as a string, and the value is the set of sources
+     * (as labels) that depend on the label.
+     */
+    public abstract Map<String, Set<String>> getUsedByMap();
+
+    /**
+     * Returns the set of labels that are not dependencies for other labels in the workspace. If A depends on B, which
+     * depends on C, this method will return A.
+     */
+    public abstract Set<String> getRootLabels();
+
+    /**
+     * Returns the set of labels that exist as dependencies to other labels in the workspace, and do not have any
+     * dependencies on other labels. If A depends on B, which depends on C, this method will return C. If a label stands
+     * alone (i.e. it has not dependency, and is not depended on by another node, it is not included).
+     */
+    public abstract Set<String> getLeafLabels();
+
+    /**
+     * Returns the set of labels that exist as dependencies to other labels in the workspace, and do not have any
+     * dependencies on other labels. If A depends on B, which depends on C, this method will return C. If a label stands
+     * alone (i.e. it has not dependency, and is not depended on by another node, it is not included).
+     * <p>
+     * If a label only depends on external deps (e.g. @maven//:com_spring_etc), it will be considered a leaf node only
+     * if the passed ignoreExternals is set to true
+     */
+    public abstract Set<String> getLeafLabels(boolean ignoreExternals);
+
+    // ANALYSIS
+
+    /**
+     * Using the computed dependency graph, order the passed labels such that no label appears in the list prior to any
+     * label it depends on.
+     * <p>
+     * Note that there is almost always multiple valid solutions for any given graph+label selection.
+     */
+    public abstract List<BazelPackageLocation> orderLabels(Set<BazelPackageLocation> selectedLabels);
+
+    /**
+     * Using the computed dependency graph, order the passed labels such that no label appears in the list prior to any
+     * label it depends on.
+     * <p>
+     * Note that there is almost always multiple valid solutions for any given graph+label selection.
+     */
+    public abstract List<BazelPackageLocation> orderLabels(List<BazelPackageLocation> selectedLabels);
+
+    /**
+     * Using the computed dependency graph, order the passed labels such that no label appears in the list prior to any
+     * label it depends on.
+     * <p>
+     * Note that there is almost always multiple valid solutions for any given graph+label selection.
+     * <p>
+     * Since this method is mostly used to order packages within the active Bazel workspace, you most often will not
+     * want to navigate into the dependency graph of the external dependencies (e.g. maven) while building the
+     * dependency graph. Pass false to followExternalTransitives to trigger this performance optimization.
+     */
+    public abstract List<BazelPackageLocation> orderLabels(List<BazelPackageLocation> selectedLabels,
+            boolean followExternalTransitives);
+
+    /**
+     * Depth first search to determine if the passed <i>possibleDependency</i> is a direct or transitive dependency of
+     * the pass <i>label</i>
+     *
+     * @param label
+     * @param possibleDependency
+     * @return
+     */
+    public abstract boolean isDependency(String label, String possibleDependency);
+
+    /**
+     * Depth first search to determine if the passed <i>possibleDependency</i> is a direct or transitive dependency of
+     * the passed <i>label</i>. This version of the method allows the caller to pass a cache object (opaque). If you
+     * will call isDependency many times, with repetitive crawls of the dependency graph, the cache will be used so we
+     * only compute areas of the graph once.
+     *
+     * @param label
+     * @param possibleDependency
+     * @param depCache
+     */
+    public abstract boolean isDependency(String label, String possibleDependency, Map<String, Boolean> depCache);
+
+    /**
+     * Depth first search to determine if the passed <i>possibleDependency</i> is a direct or transitive dependency of
+     * the passed <i>label</i>. This version of the method allows the caller to pass a cache object (opaque). If you
+     * will call isDependency many times, with repetitive crawls of the dependency graph, the cache will be used so we
+     * only compute areas of the graph once.
+     *
+     * @param label
+     * @param possibleDependency
+     * @param depCache
+     * @param followExternalTransitives
+     *            if false, will not look for the possibleDependency if it is a transitive of an external dependency
+     *            (e.g. //abc depends on @maven//:foo which depends on @maven//:bar; this method will return false for
+     *            label=//abc and possibleDependency=@maven//:bar). This is a performance optimization.
+     */
+    public abstract boolean isDependency(String label, String possibleDependency, Map<String, Boolean> depCache,
+            boolean followExternalTransitives);
+
+}

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/BazelDependencyGraphBuilder.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/BazelDependencyGraphBuilder.java
@@ -1,0 +1,21 @@
+package com.salesforce.bazel.sdk.model.graph;
+
+import java.util.Map;
+
+/**
+ * Interface to implement to wire up a new implementation of BazelDependencyGraph.
+ */
+public interface BazelDependencyGraphBuilder {
+
+    /**
+     * Method called by the BazelDependencyGraphFactory to each configured builder, until one returns a non-null graph.
+     * <p>
+     * The options are implementation specific. Graph implementors are expected to publish a set of supported options
+     * that callers can provide.
+     * <p>
+     * Implementations can choose to build a graph, or return null to abstain and let another later builder build it.
+     * The params may give hints as to whether this method should return a real impl or not.
+     */
+    BazelDependencyGraph build(String caller, Map<String, String> options);
+
+}

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/BazelDependencyGraphFactory.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/BazelDependencyGraphFactory.java
@@ -1,0 +1,39 @@
+package com.salesforce.bazel.sdk.model.graph;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class BazelDependencyGraphFactory {
+
+    /**
+     * List of configured builders. Builders earlier in the list will take precedence over later builders.
+     * <p>
+     * If you create a new implementation of BazelDependencyGraph, add a builder for it at the head of this list so that
+     * your implementation will be used instead.
+     */
+    public static List<BazelDependencyGraphBuilder> builders = new ArrayList<>();
+    static {
+        // unless the user configures a custom graph impl, the default inmemory graph will be built 
+        builders.add(new InMemoryDependencyGraphBuilder());
+    }
+
+    /**
+     * Finds a builder that can build a dependency graph, and builds it. After the initial build, the caller will need
+     * to fill in the graph using the addDependency() method for every edge in the graph.
+     * <p>
+     * The caller parameter is intended to include the caller name (e.g. AspectDependencyGraphFactory) which may be used
+     * to determine what type of graph is built, and/or for logging purposes. The options map is implementation specific
+     * - the graphs that are configured will publish options that may be available.
+     */
+    public static BazelDependencyGraph build(String caller, Map<String, String> options) {
+        for (BazelDependencyGraphBuilder builder : builders) {
+            BazelDependencyGraph graph = builder.build(caller, options);
+            if (graph != null) {
+                return graph;
+            }
+        }
+        return null;
+    }
+
+}

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/InMemoryDependencyGraph.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/InMemoryDependencyGraph.java
@@ -1,4 +1,4 @@
-package com.salesforce.bazel.sdk.model;
+package com.salesforce.bazel.sdk.model.graph;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 
 /**
  * The Bazel dependency graph of the entire workspace. This is implemented using simple Java JDK primitives rather than
@@ -38,9 +39,9 @@ import com.salesforce.bazel.sdk.logging.LogHelper;
  * cases, but there are some cases that can't be modeled. If //a/b/c:foo depends on //a/d/e:bar which depends on
  * //a/b/c:fooz, this graph will fail to model it because foo => bar => fooz would be seen as a cyclic dependency.
  */
-public class BazelDependencyGraph {
+public class InMemoryDependencyGraph extends BazelDependencyGraph {
 
-    private static final LogHelper LOG = LogHelper.log(BazelDependencyGraph.class);
+    private static final LogHelper LOG = LogHelper.log(InMemoryDependencyGraph.class);
 
     // lookup maps
 
@@ -69,18 +70,21 @@ public class BazelDependencyGraph {
     /**
      * Callers should use the factories to construct the graph.
      */
-    public BazelDependencyGraph() {}
+    public InMemoryDependencyGraph() {}
 
     // CONSTRUCTION
 
     /**
-     * Makes a dependency from source -> dep
+     * Makes a dependency from source -> dep at the package level. For some use cases, package level dependencies are
+     * sufficient (//a/b/c), but in other cases target level dependencies are needed (//a/b/c:d). The caller of this
+     * method should provide as much detail as is available.
      *
      * @param sourceLabel
-     *            the label for the source package (//a/b/c)
+     *            the label for the source package (e.g. //a/b/c or //a/b/c:d)
      * @param depLabel
-     *            the label for the depended-on package (//foo)
+     *            the label for the depended-on package (e.g. //foo or //foo:bar)
      */
+    @Override
     public void addDependency(String sourceLabel, String depLabel) {
         allDepLabels.add(depLabel);
         allSourceLabels.add(sourceLabel);
@@ -132,6 +136,7 @@ public class BazelDependencyGraph {
      * Provides a map for tracking forward deps. The key is the label as a string, and the value is the set of
      * dependencies (as labels) for the source.
      */
+    @Override
     public Map<String, Set<String>> getDependsOnMap() {
         return dependsOnMap;
     }
@@ -140,6 +145,7 @@ public class BazelDependencyGraph {
      * Provides a map for tracking reverse deps. The key is the label as a string, and the value is the set of sources
      * (as labels) that depend on the label.
      */
+    @Override
     public Map<String, Set<String>> getUsedByMap() {
         return usedByMap;
     }
@@ -148,6 +154,7 @@ public class BazelDependencyGraph {
      * Returns the set of labels that are not dependencies for other labels in the workspace. If A depends on B, which
      * depends on C, this method will return A.
      */
+    @Override
     public Set<String> getRootLabels() {
         return rootLabels;
     }
@@ -157,6 +164,7 @@ public class BazelDependencyGraph {
      * dependencies on other labels. If A depends on B, which depends on C, this method will return C. If a label stands
      * alone (i.e. it has not dependency, and is not depended on by another node, it is not included).
      */
+    @Override
     public Set<String> getLeafLabels() {
         return leafLabels;
     }
@@ -169,6 +177,7 @@ public class BazelDependencyGraph {
      * If a label only depends on external deps (e.g. @maven//:com_spring_etc), it will be considered a leaf node only
      * if the passed ignoreExternals is set to true
      */
+    @Override
     public Set<String> getLeafLabels(boolean ignoreExternals) {
         if (ignoreExternals) {
             return leafLabelsIgnoreExternals;
@@ -184,6 +193,7 @@ public class BazelDependencyGraph {
      * <p>
      * Note that there is almost always multiple valid solutions for any given graph+label selection.
      */
+    @Override
     public List<BazelPackageLocation> orderLabels(Set<BazelPackageLocation> selectedLabels) {
         LinkedList<BazelPackageLocation> selectedLabelsList = new LinkedList<>();
         selectedLabelsList.addAll(selectedLabels);
@@ -196,6 +206,7 @@ public class BazelDependencyGraph {
      * <p>
      * Note that there is almost always multiple valid solutions for any given graph+label selection.
      */
+    @Override
     public List<BazelPackageLocation> orderLabels(List<BazelPackageLocation> selectedLabels) {
         return orderLabels(selectedLabels, true);
     }
@@ -210,6 +221,7 @@ public class BazelDependencyGraph {
      * want to navigate into the dependency graph of the external dependencies (e.g. maven) while building the
      * dependency graph. Pass false to followExternalTransitives to trigger this performance optimization.
      */
+    @Override
     public List<BazelPackageLocation> orderLabels(List<BazelPackageLocation> selectedLabels,
             boolean followExternalTransitives) {
         LinkedList<BazelPackageLocation> orderedLabels = null;
@@ -271,6 +283,7 @@ public class BazelDependencyGraph {
      * @param possibleDependency
      * @return
      */
+    @Override
     public boolean isDependency(String label, String possibleDependency) {
         boolean isDep = isDependencyRecur(label, possibleDependency, null, new HashSet<>(), true);
         return isDep;
@@ -286,6 +299,7 @@ public class BazelDependencyGraph {
      * @param possibleDependency
      * @param depCache
      */
+    @Override
     public boolean isDependency(String label, String possibleDependency, Map<String, Boolean> depCache) {
         boolean isDep = isDependencyRecur(label, possibleDependency, depCache, new HashSet<>(), true);
         return isDep;
@@ -305,6 +319,7 @@ public class BazelDependencyGraph {
      *            (e.g. //abc depends on @maven//:foo which depends on @maven//:bar; this method will return false for
      *            label=//abc and possibleDependency=@maven//:bar). This is a performance optimization.
      */
+    @Override
     public boolean isDependency(String label, String possibleDependency, Map<String, Boolean> depCache,
             boolean followExternalTransitives) {
         boolean isDep =

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/InMemoryDependencyGraphBuilder.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/InMemoryDependencyGraphBuilder.java
@@ -1,0 +1,15 @@
+package com.salesforce.bazel.sdk.model.graph;
+
+import java.util.Map;
+
+/**
+ * BazelDependencyGraphBuilder that builds InMemoryDependencyGraph instances
+ */
+public class InMemoryDependencyGraphBuilder implements BazelDependencyGraphBuilder {
+
+    @Override
+    public BazelDependencyGraph build(String caller, Map<String, String> options) {
+        return new InMemoryDependencyGraph();
+    }
+
+}

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/InMemoryPackageLocation.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/graph/InMemoryPackageLocation.java
@@ -1,7 +1,9 @@
-package com.salesforce.bazel.sdk.model;
+package com.salesforce.bazel.sdk.model.graph;
 
 import java.io.File;
 import java.util.List;
+
+import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 
 /**
  * In memory package location.
@@ -9,17 +11,17 @@ import java.util.List;
  * TODO we need to rethink BazelPackageLocation abstraction.
  *
  */
-public class InMemoryBazelPackageLocation implements BazelPackageLocation {
+public class InMemoryPackageLocation implements BazelPackageLocation {
     private String path;
     private String lastSegment;
 
     // root node
-    public InMemoryBazelPackageLocation() {
+    public InMemoryPackageLocation() {
         this.path = null;
         this.lastSegment = "";
     }
 
-    public InMemoryBazelPackageLocation(String path) {
+    public InMemoryPackageLocation(String path) {
         if (path.startsWith("//")) {
             this.path = path.substring(2);
         } else {

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
@@ -15,6 +15,10 @@ public class BazelPathHelper {
     // for Bazel specific code. 
     public static final String BAZEL_SLASH = "/";
 
+    // Colon character for Bazel paths that delimits the target; this is provided as a constant to help code searches
+    // for Bazel specific code. 
+    public static final String BAZEL_COLON = ":";
+
     // Slash character for unix file paths; this is provided as a constant to help code searches
     // for Unix specific code. 
     public static final String UNIX_SLASH = "/";

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import com.salesforce.bazel.sdk.model.BazelBuildFile;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Object that encapsulates the logic and state regarding the active targets configured for a BazelProject.
@@ -74,7 +75,7 @@ public class BazelProjectTargets {
 
     public void activateWildcardTarget(String wildcardTarget) {
         this.isActivatedWildcardTarget = true;
-        this.configuredTargets.add(projectBazelLabel + ":" + wildcardTarget);
+        this.configuredTargets.add(projectBazelLabel + BazelPathHelper.BAZEL_COLON + wildcardTarget);
     }
 
     public void activateSpecificTargets(Set<String> activatedTargets) {

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
@@ -44,6 +44,8 @@ public class ProjectView {
     static String TARGETS_SECTION = "targets:";
     static String DIRECTORIES_COMMENT = "# Add the directories you want added as source here";
     static String INDENT = "  ";
+    static String SECTION_COLON = ":"; // section headers have a trailing colon
+    static String COMMENT_PREFIX = "#";
 
     private final File rootWorkspaceDirectory;
     private final Map<BazelPackageLocation, Integer> packageToLineNumber;
@@ -219,7 +221,7 @@ public class ProjectView {
             if (line.isEmpty()) {
                 continue;
             }
-            if (line.startsWith("#")) {
+            if (line.startsWith(COMMENT_PREFIX)) {
                 continue;
             }
             if (line.equals(DIRECTORIES_SECTION)) {
@@ -230,7 +232,7 @@ public class ProjectView {
                 withinDirectoriesSection = false;
                 withinTargetsSection = true;
                 continue;
-            } else if (line.endsWith(":")) {
+            } else if (line.endsWith(SECTION_COLON)) {
                 // some other yet unknown section
                 withinDirectoriesSection = false;
                 withinTargetsSection = false;

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/ProjectOrderResolverImpl.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/ProjectOrderResolverImpl.java
@@ -2,11 +2,11 @@ package com.salesforce.bazel.sdk.workspace;
 
 import java.util.List;
 
-import com.salesforce.bazel.sdk.aspect.AspectDependencyGraphBuilder;
+import com.salesforce.bazel.sdk.aspect.AspectDependencyGraphFactory;
 import com.salesforce.bazel.sdk.aspect.AspectTargetInfos;
 import com.salesforce.bazel.sdk.logging.LogHelper;
-import com.salesforce.bazel.sdk.model.BazelDependencyGraph;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.model.graph.BazelDependencyGraph;
 
 /**
  * Orders modules for import such that upstream dependencies are imported before downstream dependencies.
@@ -56,7 +56,7 @@ public class ProjectOrderResolverImpl implements ProjectOrderResolver {
         // first, generate the dependency graph for the entire workspace
         List<BazelPackageLocation> orderedModules = null;
         try {
-            BazelDependencyGraph workspaceDepGraph = AspectDependencyGraphBuilder.build(aspects, false);
+            BazelDependencyGraph workspaceDepGraph = AspectDependencyGraphFactory.build(aspects, false);
             boolean followExternalTransitives = false;
             orderedModules = workspaceDepGraph.orderLabels(selectedPackages, followExternalTransitives);
 

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/graph/BazelDependencyGraphFactoryTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/graph/BazelDependencyGraphFactoryTest.java
@@ -1,0 +1,55 @@
+package com.salesforce.bazel.sdk.graph;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.salesforce.bazel.sdk.model.graph.BazelDependencyGraph;
+import com.salesforce.bazel.sdk.model.graph.BazelDependencyGraphBuilder;
+import com.salesforce.bazel.sdk.model.graph.BazelDependencyGraphFactory;
+import com.salesforce.bazel.sdk.model.graph.InMemoryDependencyGraph;
+
+public class BazelDependencyGraphFactoryTest {
+
+    @Test
+    public void testBuilderInvocation() {
+        List<BazelDependencyGraphBuilder> origBuilders = BazelDependencyGraphFactory.builders;
+        TestDependencyGraphBuilder testBuilder = new TestDependencyGraphBuilder();
+        BazelDependencyGraphFactory.builders.add(0, testBuilder);
+        Map<String, String> options = new HashMap<>();
+
+        BazelDependencyGraph mockGraph = BazelDependencyGraphFactory.build("testBuilderInvocation", options);
+        assertTrue(testBuilder.built);
+        testBuilder.built = false;
+        assertNotNull(mockGraph);
+
+        options.put("pass", "true");
+        BazelDependencyGraph inmemoryGraph = BazelDependencyGraphFactory.build("testBuilderInvocation", options);
+        assertFalse(testBuilder.built);
+        assertNotNull(inmemoryGraph);
+        assertTrue(inmemoryGraph instanceof InMemoryDependencyGraph);
+
+        BazelDependencyGraphFactory.builders = origBuilders;
+    }
+
+    private static class TestDependencyGraphBuilder implements BazelDependencyGraphBuilder {
+        public boolean built = false;
+
+        @Override
+        public BazelDependencyGraph build(String caller, Map<String, String> options) {
+            if (options.containsKey("pass")) {
+                return null;
+            }
+            built = true;
+            return Mockito.mock(BazelDependencyGraph.class);
+        }
+
+    }
+}

--- a/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/graph/InMemoryDependencyGraphTest.java
+++ b/sdk/bazel-java-sdk/src/test/java/com/salesforce/bazel/sdk/graph/InMemoryDependencyGraphTest.java
@@ -1,4 +1,4 @@
-package com.salesforce.bazel.sdk.model;
+package com.salesforce.bazel.sdk.graph;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -9,11 +9,15 @@ import java.util.Set;
 
 import org.junit.Test;
 
-public class BazelDependencyGraphTest {
+import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.model.graph.InMemoryDependencyGraph;
+import com.salesforce.bazel.sdk.model.graph.InMemoryPackageLocation;
+
+public class InMemoryDependencyGraphTest {
 
     @Test
     public void testSingleTree() {
-        BazelDependencyGraph graph = new BazelDependencyGraph();
+        InMemoryDependencyGraph graph = new InMemoryDependencyGraph();
 
         graph.addDependency("rootA", "midA1");
         graph.addDependency("rootA", "midA2");
@@ -34,9 +38,9 @@ public class BazelDependencyGraphTest {
 
         // test ordering alg
         Set<BazelPackageLocation> selectedLabels = new LinkedHashSet<>();
-        selectedLabels.add(new InMemoryBazelPackageLocation("midA2"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("rootA"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("leafA2"));
+        selectedLabels.add(new InMemoryPackageLocation("midA2"));
+        selectedLabels.add(new InMemoryPackageLocation("rootA"));
+        selectedLabels.add(new InMemoryPackageLocation("leafA2"));
         List<BazelPackageLocation> orderedLabels = graph.orderLabels(selectedLabels);
         assertEquals("leafA2", orderedLabels.get(0).getBazelPackageName());
         assertEquals("midA2", orderedLabels.get(1).getBazelPackageName());
@@ -45,7 +49,7 @@ public class BazelDependencyGraphTest {
 
     @Test
     public void testMultiDistinctTrees() {
-        BazelDependencyGraph graph = new BazelDependencyGraph();
+        InMemoryDependencyGraph graph = new InMemoryDependencyGraph();
 
         graph.addDependency("rootA", "midA1");
         graph.addDependency("rootA", "midA2");
@@ -76,10 +80,10 @@ public class BazelDependencyGraphTest {
 
         // test ordering alg
         Set<BazelPackageLocation> selectedLabels = new LinkedHashSet<>();
-        selectedLabels.add(new InMemoryBazelPackageLocation("rootA"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("midA1"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("leafA1"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("rootB"));
+        selectedLabels.add(new InMemoryPackageLocation("rootA"));
+        selectedLabels.add(new InMemoryPackageLocation("midA1"));
+        selectedLabels.add(new InMemoryPackageLocation("leafA1"));
+        selectedLabels.add(new InMemoryPackageLocation("rootB"));
         List<BazelPackageLocation> orderedLabels = graph.orderLabels(selectedLabels);
         assertEquals("leafA1", orderedLabels.get(0).getBazelPackageName());
         assertEquals("midA1", orderedLabels.get(1).getBazelPackageName());
@@ -89,7 +93,7 @@ public class BazelDependencyGraphTest {
 
     @Test
     public void testMultiConjoinedTrees() {
-        BazelDependencyGraph graph = new BazelDependencyGraph();
+        InMemoryDependencyGraph graph = new InMemoryDependencyGraph();
 
         graph.addDependency("rootA", "mid1");
         graph.addDependency("rootA", "mid2");
@@ -113,9 +117,9 @@ public class BazelDependencyGraphTest {
 
         // test ordering alg
         Set<BazelPackageLocation> selectedLabels = new LinkedHashSet<>();
-        selectedLabels.add(new InMemoryBazelPackageLocation("rootA"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("mid1"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("leaf1"));
+        selectedLabels.add(new InMemoryPackageLocation("rootA"));
+        selectedLabels.add(new InMemoryPackageLocation("mid1"));
+        selectedLabels.add(new InMemoryPackageLocation("leaf1"));
         List<BazelPackageLocation> orderedLabels = graph.orderLabels(selectedLabels);
         assertEquals("leaf1", orderedLabels.get(0).getBazelPackageName());
         assertEquals("mid1", orderedLabels.get(1).getBazelPackageName());
@@ -124,7 +128,7 @@ public class BazelDependencyGraphTest {
 
     @Test
     public void testExternalDeps() {
-        BazelDependencyGraph graph = new BazelDependencyGraph();
+        InMemoryDependencyGraph graph = new InMemoryDependencyGraph();
 
         graph.addDependency("rootA", "midA1");
         graph.addDependency("rootA", "midA2");
@@ -159,9 +163,9 @@ public class BazelDependencyGraphTest {
 
         // test ordering alg
         Set<BazelPackageLocation> selectedLabels = new LinkedHashSet<>();
-        selectedLabels.add(new InMemoryBazelPackageLocation("midA2"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("rootA"));
-        selectedLabels.add(new InMemoryBazelPackageLocation("leafA2"));
+        selectedLabels.add(new InMemoryPackageLocation("midA2"));
+        selectedLabels.add(new InMemoryPackageLocation("rootA"));
+        selectedLabels.add(new InMemoryPackageLocation("leafA2"));
         List<BazelPackageLocation> orderedLabels = graph.orderLabels(selectedLabels);
         assertEquals("leafA2", orderedLabels.get(0).getBazelPackageName());
         assertEquals("midA2", orderedLabels.get(1).getBazelPackageName());


### PR DESCRIPTION
The current dep graph impl was hard coded. It is an in-memory solution, which works for some use cases.

But this PR makes the graph impl pluggable, which means we can create impls based on:
- a database
- a file
- a remote graph service

Also included is some early prep to make the in-memory graph capable of tracking deps at the level of targets, instead of just labels.