### PR TITLE
formalize bazel label components more

### DIFF
--- a/examples/src/main/java/com/salesforce/bazel/app/analyzer/BazelAnalyzerApp.java
+++ b/examples/src/main/java/com/salesforce/bazel/app/analyzer/BazelAnalyzerApp.java
@@ -184,17 +184,21 @@ public class BazelAnalyzerApp {
             // optional third parameter is the package to scope the analysis to (- is a placeholder arg to signal there is no scope)
             if (!args[2].equals("-")) {
                 rootPackageToAnalyze = args[2];
-                if (!rootPackageToAnalyze.startsWith("//")) {
+                if (!rootPackageToAnalyze.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
                     throw new IllegalArgumentException(
                             "The third argument is expected to be a Bazel package label, such as //foo/bar");
                 }
-                if (rootPackageToAnalyze.endsWith("*")) {
+                if (rootPackageToAnalyze.endsWith(BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS)) {
                     throw new IllegalArgumentException(
-                            "The third argument is expected to be a Bazel package label, such as //foo/bar");
+                            "The third argument is expected to be a concrete Bazel package label, such as //foo/bar");
                 }
-                if (rootPackageToAnalyze.endsWith("...")) {
+                if (rootPackageToAnalyze.endsWith(BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS_STAR)) {
                     throw new IllegalArgumentException(
-                            "The third argument is expected to be a Bazel package label, such as //foo/bar");
+                            "The third argument is expected to be a concrete Bazel package label, such as //foo/bar");
+                }
+                if (rootPackageToAnalyze.endsWith(BazelPathHelper.BAZEL_WILDCARD_ALLPACKAGES)) {
+                    throw new IllegalArgumentException(
+                            "The third argument is expected to be a concrete Bazel package label, such as //foo/bar");
                 }
                 // remove leading slashes
                 rootPackageToAnalyze = rootPackageToAnalyze.substring(2);

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/MockCommand.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/MockCommand.java
@@ -143,11 +143,12 @@ public class MockCommand implements Command {
             return true;
         }
 
-        if (target.startsWith("//")) {
+        if (target.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
             target = target.substring(2);
         }
         String packageLabel = target;
-        String ruleName = "*";
+        // TODO also need to check for ... and :all
+        String ruleName = BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS_STAR;
         int colonIndex = target.indexOf(BazelPathHelper.BAZEL_COLON);
         if (colonIndex >= 0) {
             packageLabel = target.substring(0, colonIndex);
@@ -157,7 +158,7 @@ public class MockCommand implements Command {
         if (testWorkspaceFactory.workspaceDescriptor.getCreatedPackageByName(packageLabel) == null) {
             returnFalseOrThrow(target);
         }
-        if (!ruleName.equals("*")) {
+        if (!ruleName.equals(BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS_STAR)) {
             // * ruleName is always valid, but if there is a specific rule we need to check
             if (testWorkspaceFactory.workspaceDescriptor.createdTargets.get(target) == null) {
                 returnFalseOrThrow(target);

--- a/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/type/MockBuildCommand.java
+++ b/sdk/bazel-java-sdk-test-framework/src/main/java/com/salesforce/bazel/sdk/command/test/type/MockBuildCommand.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutput;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutputMatcher;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
 
 /**
@@ -68,7 +69,9 @@ public class MockBuildCommand extends MockCommand {
 
         for (String packagePath : testWorkspaceFactory.workspaceDescriptor.aspectFileSets.keySet()) {
             // the last arg is the package path with the wildcard target (//projects/libs/javalib0:*)
-            String wildcardTarget = "//" + packagePath + ":.*"; // TODO this is returning the same set of aspects for each target in a package
+            // TODO this is returning the same set of aspects for each target in a package
+            String wildcardTarget =
+                    BazelPathHelper.BAZEL_ROOT_SLASHES + packagePath + BazelPathHelper.BAZEL_COLON + ".*";
             MockCommandSimulatedOutputMatcher aspectCommandMatcher3 =
                     new MockCommandSimulatedOutputMatcher(7, wildcardTarget);
 

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/graph/InMemoryPackageLocation.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/graph/InMemoryPackageLocation.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.List;
 
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * In memory package location.
@@ -22,7 +23,7 @@ public class InMemoryPackageLocation implements BazelPackageLocation {
     }
 
     public InMemoryPackageLocation(String path) {
-        if (path.startsWith("//")) {
+        if (path.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
             this.path = path.substring(2);
         } else {
             this.path = path;

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
@@ -376,7 +376,7 @@ public class BazelPackageInfo implements BazelPackageLocation {
         if ((bazelPackagePath == null) || bazelPackagePath.isEmpty()) {
             throw new IllegalArgumentException("An empty path was passed to BazelPackageInfo.findByPackage()");
         }
-        if (!bazelPackagePath.startsWith("//")) {
+        if (!bazelPackagePath.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
             throw new IllegalArgumentException(
                     "You must pass a Bazel path (e.g. //projects/libs/apple) to BazelPackageInfo.findByPackage(), got ["
                             + bazelPackagePath + "]");

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelWorkspace.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelWorkspace.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandOptions;
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.BazelWorkspaceMetadataStrategy;
 import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
 
@@ -140,7 +141,7 @@ public class BazelWorkspace {
     public List<String> getTargetsForBazelQuery(String query) {
         List<String> results = new ArrayList<String>();
         for (String line : metadataStrategy.computeBazelQuery(query)) {
-            if (line.startsWith("//")) {
+            if (line.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
                 results.add(line);
             }
         }

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
@@ -11,16 +11,32 @@ import com.salesforce.bazel.sdk.logging.LogHelper;
 public class BazelPathHelper {
     private static final LogHelper LOG = LogHelper.log(BazelPathHelper.class);
 
-    // Slash character for Bazel paths; this is provided as a constant to help code searches
-    // for Bazel specific code. 
+    // BAZEL PATH ELEMENTS
+
+    // Double slash characters for root of Bazel paths
+    public static final String BAZEL_ROOT_SLASHES = "//";
+
+    // All packages wildcard 
+    public static final String BAZEL_ALL_REPO_PACKAGES = "//...";
+
+    // Slash character for Bazel paths
     public static final String BAZEL_SLASH = "/";
 
-    // Colon character for Bazel paths that delimits the target; this is provided as a constant to help code searches
-    // for Bazel specific code. 
+    // Colon character for Bazel paths that delimits the target
     public static final String BAZEL_COLON = ":";
 
-    // Slash character for unix file paths; this is provided as a constant to help code searches
-    // for Unix specific code. 
+    // Wildcard used as a package, that identifies all packages at the current level or below
+    public static final String BAZEL_WILDCARD_ALLPACKAGES = "...";
+
+    // Wildcard used as a target, that identifies all targets 
+    public static final String BAZEL_WILDCARD_ALLTARGETS = "all";
+
+    // Wildcard used as a target, that identifies all targets including implicit targets (_deploy.jar etc) 
+    public static final String BAZEL_WILDCARD_ALLTARGETS_STAR = "*";
+
+    // FILE SYSTEM PATH ELEMENTS
+
+    // Slash character for unix file paths
     public static final String UNIX_SLASH = "/";
 
     // Backslash character; this is provided as a constant to help code searches
@@ -34,8 +50,7 @@ public class BazelPathHelper {
     // Java requires a backslash to encode a backslash in the String (2x2=4)
     public static final String WINDOWS_BACKSLASH_REGEX = "\\\\";
 
-    // Slash character for file paths in jar files; this is provided as a constant to help code searches
-    // for Jar specific code. 
+    // Slash character for file paths in jar files
     public static final String JAR_SLASH = "/";
 
     /**

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Represents a line in a project view file.
@@ -62,9 +63,9 @@ public class ProjectViewPackageLocation implements BazelPackageLocation {
             // somehow handle that workspace differently
             // Docs should indicate that a better practice is to keep the root dir free of an actual package
             // For now, assume that anything referring to the root dir is a proxy for 'whole repo'
-            return "//...";
+            return BazelPathHelper.BAZEL_ALL_REPO_PACKAGES;
         }
-        return "//" + packagePath;
+        return BazelPathHelper.BAZEL_ROOT_SLASHES + packagePath;
     }
 
     @Override

--- a/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
+++ b/sdk/bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
@@ -38,6 +38,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 public interface BazelConstants {
 
     /**
@@ -55,6 +57,7 @@ public interface BazelConstants {
     /**
      * The targets configured by default for each imported Bazel package.
      */
-    Collection<String> DEFAULT_PACKAGE_TARGETS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("*")));
+    Collection<String> DEFAULT_PACKAGE_TARGETS =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS_STAR)));
 
 }


### PR DESCRIPTION
Continue to strengthen type checking of paths in the SDK to prevent bugs (especially in Windows). Progress for Issue #4. 